### PR TITLE
Fix query when validTo is empty

### DIFF
--- a/pkg/consent.go
+++ b/pkg/consent.go
@@ -367,7 +367,7 @@ func (cs *ConsentStore) QueryConsent(context context.Context, _actor *string, _c
 		Table("consent_record").
 		Select("id").
 		Where("id IN (?)", expr).
-		Where("julianday(valid_from) <= julianday(?) AND julianday(valid_to) > julianday(?)", validAt, validAt).
+		Where("julianday(valid_from) <= julianday(?) AND (valid_to IS NULL or julianday(valid_to) > julianday(?))", validAt, validAt).
 		Rows()
 
 	defer func() {

--- a/pkg/consent_test.go
+++ b/pkg/consent_test.go
@@ -669,9 +669,8 @@ func TestConsentStore_QueryConsent(t *testing.T) {
 						},
 					},
 				},
-				{
+				{ // No validTo, means always valid
 					ValidFrom: time.Now().Add(time.Hour * -24),
-					ValidTo:   &validTo,
 					Hash:      random.String(8),
 					UUID:      "2",
 					DataClasses: []DataClass{


### PR DESCRIPTION
Query for consents without validTo date always returns empty set.