### PR TITLE
Fix dup record

### DIFF
--- a/pkg/consent.go
+++ b/pkg/consent.go
@@ -280,6 +280,19 @@ func (cs *ConsentStore) RecordConsent(context context.Context, consent []Patient
 				Version:          1,
 			}
 
+			// check if record already exists based on hash
+			var ecr ConsentRecord
+			if err := tx.Where("hash = ?", cr.Hash).First(&ecr).Error; err != nil {
+				if !gorm.IsRecordNotFoundError(err) {
+					return fmt.Errorf("error when cheking for duplicate consent record with hash %s: %w", cr.Hash, err)
+				}
+			}
+
+			// ignore existing record
+			if ecr.Hash == cr.Hash {
+				continue
+			}
+
 			// if this is an update to an existing entry, find UUID and version
 			if cr.PreviousHash != nil {
 				var pcr ConsentRecord

--- a/pkg/consent.go
+++ b/pkg/consent.go
@@ -282,11 +282,7 @@ func (cs *ConsentStore) RecordConsent(context context.Context, consent []Patient
 
 			// check if record already exists based on hash
 			var ecr ConsentRecord
-			if err := tx.Where("hash = ?", cr.Hash).First(&ecr).Error; err != nil {
-				if !gorm.IsRecordNotFoundError(err) {
-					return fmt.Errorf("error when cheking for duplicate consent record with hash %s: %w", cr.Hash, err)
-				}
-			}
+			tx.Where("hash = ?", cr.Hash).First(&ecr)
 
 			// ignore existing record
 			if ecr.Hash == cr.Hash {

--- a/pkg/consent_test.go
+++ b/pkg/consent_test.go
@@ -44,34 +44,34 @@ func TestConsentStore_RecordConsent(t *testing.T) {
 	client := defaultConsentStore()
 	defer client.Shutdown()
 
-	t.Run("It sets the version number to 1", func(t *testing.T) {
-		validTo := time.Now().Add(time.Hour * +12)
+	validTo := time.Now().Add(time.Hour * +12)
 
-		rules := []PatientConsent{
-			{
-				ID:        random.String(8),
-				Actor:     "actor",
-				Custodian: "custodian",
-				Subject:   "subject",
+	rules := []PatientConsent{
+		{
+			ID:        random.String(8),
+			Actor:     "actor",
+			Custodian: "custodian",
+			Subject:   "subject",
 
-				Records: []ConsentRecord{
-					{
-						ValidFrom: time.Now().Add(time.Hour * -24),
-						ValidTo:   &validTo,
-						Hash:      "234caef",
-						DataClasses: []DataClass{
-							{
-								Code: "resource",
-							},
+			Records: []ConsentRecord{
+				{
+					ValidFrom: time.Now().Add(time.Hour * -24),
+					ValidTo:   &validTo,
+					Hash:      "234caef",
+					DataClasses: []DataClass{
+						{
+							Code: "resource",
 						},
-						UUID: uuid.NewV4().String(),
 					},
+					UUID: uuid.NewV4().String(),
 				},
 			},
-		}
+		},
+	}
 
-		err := client.RecordConsent(context.TODO(), rules)
+	err := client.RecordConsent(context.TODO(), rules)
 
+	t.Run("It sets the version number to 1", func(t *testing.T) {
 		if assert.NoError(t, err) {
 			a := "actor"
 			s := "subject"
@@ -81,6 +81,12 @@ func TestConsentStore_RecordConsent(t *testing.T) {
 				assert.Equal(t, uint(1), pcs[0].Records[0].Version)
 			}
 		}
+	})
+
+	t.Run("ConsentRecord with existing hash can be recorded with no changes as result", func(t *testing.T) {
+		err := client.RecordConsent(context.TODO(), rules)
+
+		assert.NoError(t, err)
 	})
 }
 

--- a/pkg/consent_test.go
+++ b/pkg/consent_test.go
@@ -292,6 +292,7 @@ func TestConsentStore_RecordConsent_AuthConsent(t *testing.T) {
 		err = client.RecordConsent(context.TODO(), rules)
 		if assert.NoError(t, err) {
 			// update again
+			rules[0].Records[0].Hash = fmt.Sprintf("%s_3", r)
 			err = client.RecordConsent(context.TODO(), rules)
 			assert.Error(t, err) // unique constraint violation
 		}


### PR DESCRIPTION
Just ignore a record when the hash is already known, no data can change anyway.

Fixes #55 